### PR TITLE
Add absolute path for service-worker.js

### DIFF
--- a/template/build/service-worker-prod.js
+++ b/template/build/service-worker-prod.js
@@ -16,7 +16,7 @@
   window.addEventListener('load', function() {
       if ('serviceWorker' in navigator &&
           (window.location.protocol === 'https:' || isLocalhost)) {
-        navigator.serviceWorker.register('service-worker.js')
+        navigator.serviceWorker.register(`${window.location.origin}/service-worker.js`)
         .then(function(registration) {
           // updatefound is fired if service-worker.js changes.
           registration.onupdatefound = function() {


### PR DESCRIPTION
Prevents the following error by setting an absolute path to the service-worker

```
DOMException: Failed to register a ServiceWorker: The script has an unsupported MIME type ('text/html').
```
Not sure if the polyfill is necessary:

```js
if (!window.location.origin) {
  window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
}
```