### PR TITLE
Add noscript tags for fallback content

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -26,7 +26,10 @@
     <link rel="<%= chunk.initial?'preload':'prefetch' %>" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>"><% }}} %>
   </head>
   <body>
-    <div id="app">This is your fallback content in case JavaScript fails to load.</div>
+    <noscript>
+      This is your fallback content in case JavaScript fails to load.
+    </noscript>
+    <div id="app"></div>
     <!-- Todo: only include in production -->
     <%= htmlWebpackPlugin.options.serviceWorkerLoader %>
     <!-- built files will be auto injected -->


### PR DESCRIPTION
The fallback message should be seen only when JavaScript fails to load. Currently, if the app loads on a slow network, it is displayed. I added the tags outside the root element, as seen in the create-react-app template.