### PR TITLE
Configure targets.browser for babel-preset-env

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,6 +1,11 @@
 {
   "presets": [
-    ["env", { "modules": false }],
+    ["env", {
+      "modules": false,
+      "targets": {
+        "browsers": ["> 1%", "last 2 versions", "not ie <= 8"]
+      }
+    }],
     "stage-2"
   ],
   "plugins": ["transform-runtime"],


### PR DESCRIPTION
Configures `babel-preset-env` to target browsers using `browserslist`.

`babel-preset-env` does not yet consume the `browserslist` config in `package.json`. There is a [PR open](https://github.com/babel/babel-preset-env/pull/161) for adding this support. We can avoid the duplicated config(`package.json`, `.babelrc`) once this PR is merged into `babel-preset-env`.

This issue was discussed here - vuejs-templates/webpack#762