### PR TITLE
Keep comments in babel output(webpack magic comments)

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -4,7 +4,6 @@
     "stage-2"
   ],
   "plugins": ["transform-runtime"],
-  "comments": false,
   "env": {
     "test": {
       "presets": ["env", "stage-2"],


### PR DESCRIPTION
> They are necessary for webpacks "magic comments" to work, e.g. with import(/* webpackChunkName: "chunk1" */ './component.vue')

This PR is a clone of vuejs-templates/webpack#753
Linked Issue - vuejs-templates/webpack#730