### PR TITLE
Put hotMiddleware before proxyMiddleware in dev server

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -41,6 +41,10 @@ compiler.plugin('compilation', function (compilation) {
   })
 })
 
+// enable hot-reload and state-preserving
+// compilation error display
+app.use(hotMiddleware)
+
 // proxy api requests
 Object.keys(proxyTable).forEach(function (context) {
   var options = proxyTable[context]
@@ -55,10 +59,6 @@ app.use(require('connect-history-api-fallback')())
 
 // serve webpack bundle output
 app.use(devMiddleware)
-
-// enable hot-reload and state-preserving
-// compilation error display
-app.use(hotMiddleware)
 
 // serve pure static assets
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)


### PR DESCRIPTION
For me, when the proxy table has entries, hot reloading breaks.

Error in Chrome:
```
EventSource's response has a MIME type ("text/html") that is not "text/event-stream". Aborting the connection.
```

In the dev server, using the hotMiddleware before the proxyMiddleware fixes the problem.