### PR TITLE
Enable cache for eslint-loader

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -36,7 +36,8 @@ module.exports = {
         enforce: 'pre',
         include: [resolve('src'), resolve('test')],
         options: {
-          formatter: require('eslint-friendly-formatter')
+          formatter: require('eslint-friendly-formatter'),
+          cache: true
         }
       },
       {{/lint}}


### PR DESCRIPTION
Docs - [MoOx/eslint-loader#cache-default-false](https://github.com/MoOx/eslint-loader#cache-default-false)

> This option will enable caching of the linting results into a file. This is particularly useful in reducing linting time when doing a full build.

On a moderate size project(webpack template), this brought down the production build time from ~60s to ~53s.

This PR is a clone of vuejs-templates/webpack#799