### PR TITLE
minify service worker script before html inlining (#59)

### DIFF
--- a/template/build/load-minified.js
+++ b/template/build/load-minified.js
@@ -1,0 +1,9 @@
+var fs = require('fs')
+var UglifyJS = require('uglify-es')
+
+module.exports = function(filePath) {
+  var code = fs.readFileSync(filePath, 'utf-8')
+  var result = UglifyJS.minify(code)
+  if (result.error) return ''
+  return result.code
+}

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -10,6 +10,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 var SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
+var loadMinified = require('./load-minfied')
 
 var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -68,8 +69,8 @@ var webpackConfig = merge(baseWebpackConfig, {
       },
       // necessary to consistently work with multiple chunks via CommonsChunkPlugin
       chunksSortMode: 'dependency',
-      serviceWorkerLoader: `<script>${fs.readFileSync(path.join(__dirname,
-        './service-worker-prod.js'), 'utf-8')}</script>`
+      serviceWorkerLoader: `<script>${loadMinified(path.join(__dirname,
+        './service-worker-prod.js'))}</script>`
     }),
     // split vendor js into its own file
     new webpack.optimize.CommonsChunkPlugin({

--- a/template/package.json
+++ b/template/package.json
@@ -96,7 +96,8 @@
     "webpack": "^2.6.1",
     "webpack-dev-middleware": "^1.10.0",
     "webpack-hot-middleware": "^2.18.0",
-    "webpack-merge": "^4.1.0"
+    "webpack-merge": "^4.1.0",
+    "uglify-es": "^3.0.25"
   },
   "engines": {
     "node": ">= 4.0.0",


### PR DESCRIPTION
I have added the solution to minify the `service-worker-prod.js` before inlining in index.html.

The approach works for me in production here: [hnpwa-vue](https://anubhav7495.github.io/hnpwa-vue/#/news)

Requesting reviews.
Thanks.