### PR TITLE
Lighthouse best practices audit: short_name

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -14,6 +14,11 @@ module.exports = {
       "required": true,
       "message": "Project name"
     },
+    "short_name": {
+      "type": "string",
+      "required": false,
+      "message": "Project short name: fewer than 12 characters to not be truncated on homescreens (default: same as name)",
+    },
     "description": {
       "type": "string",
       "required": false,

--- a/template/static/manifest.json
+++ b/template/static/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "{{ name }}",
-  "short_name": "{{ name }}",
+  "short_name": "{{#if short_name }}{{ short_name }}{{else}}{{ name }}{{/if}}",
   "icons": [
     {
       "src": "/static/img/icons/android-chrome-192x192.png",


### PR DESCRIPTION
Should inform the user about the Lighthouse recommendation of Best Practices, rather than implicitly applying the "name" as "short_name".
> Manifest's short_name Won't Be Truncated When Displayed on Homescreen ([Lighthouse](https://developers.google.com/web/tools/lighthouse/audits/manifest-short_name-is-not-truncated))