### PR TITLE
bug(gitter): remove deprecated gitter link for community chat

### DIFF
--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -5,7 +5,7 @@
     <ul>
       <li><a href="https://vuejs.org" target="_blank" rel="noopener">Core Docs</a></li>
       <li><a href="https://forum.vuejs.org" target="_blank" rel="noopener">Forum</a></li>
-      <li><a href="https://gitter.im/vuejs/vue" target="_blank" rel="noopener">Gitter Chat</a></li>
+      <li><a href=" http://chat.vuejs.org/" target="_blank" rel="noopener">Vue Community Chat</a></li>
       <li><a href="https://twitter.com/vuejs" target="_blank" rel="noopener">Twitter</a></li>
       <li><a href="http://vuejs-templates.github.io/webpack/" target="_blank" rel="noopener">Docs for This Template</a></li>
     </ul>

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -5,7 +5,7 @@
     <ul>
       <li><a href="https://vuejs.org" target="_blank" rel="noopener">Core Docs</a></li>
       <li><a href="https://forum.vuejs.org" target="_blank" rel="noopener">Forum</a></li>
-      <li><a href=" http://chat.vuejs.org/" target="_blank" rel="noopener">Vue Community Chat</a></li>
+      <li><a href="http://chat.vuejs.org/" target="_blank" rel="noopener">Vue Community Chat</a></li>
       <li><a href="https://twitter.com/vuejs" target="_blank" rel="noopener">Twitter</a></li>
       <li><a href="http://vuejs-templates.github.io/webpack/" target="_blank" rel="noopener">Docs for This Template</a></li>
     </ul>


### PR DESCRIPTION
Links to correct chat now: http://chat.vuejs.org/