### PR TITLE
chore(package): rm unused dev-dependency lolex

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -69,7 +69,6 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.31",
     "karma-webpack": "^2.0.2",
-    "lolex": "^2.0.0",
     "mocha": "^3.2.0",
     "chai": "^3.5.0",
     "sinon": "^2.1.0",


### PR DESCRIPTION
This removes `lolex` from dev dependencies as it has not been used in the project.

This PR is a clone of vuejs-templates/webpack#803(merged)