### PR TITLE
Fix a service worker loaded from subroutes

### DIFF
--- a/template/build/service-worker-prod.js
+++ b/template/build/service-worker-prod.js
@@ -16,7 +16,7 @@
   window.addEventListener('load', function() {
       if ('serviceWorker' in navigator &&
           (window.location.protocol === 'https:' || isLocalhost)) {
-        navigator.serviceWorker.register('service-worker.js')
+        navigator.serviceWorker.register('/service-worker.js')
         .then(function(registration) {
           // updatefound is fired if service-worker.js changes.
           registration.onupdatefound = function() {


### PR DESCRIPTION
With `register('service-worker.js')`, browser will try to load the resource in foo.com/bar/service-worker.js instead of foo.com/service-worker.js.