### PR TITLE
Prevent syntax error in Internet Explorer

### DIFF
--- a/template/build/service-worker-prod.js
+++ b/template/build/service-worker-prod.js
@@ -4,7 +4,7 @@
   // Check to make sure service workers are supported in the current browser,
   // and that the current page is accessed from a secure origin. Using a
   // service worker from an insecure origin will trigger JS console errors.
-  const isLocalhost = Boolean(window.location.hostname === 'localhost' ||
+  var isLocalhost = Boolean(window.location.hostname === 'localhost' ||
       // [::1] is the IPv6 localhost address.
       window.location.hostname === '[::1]' ||
       // 127.0.0.1/8 is considered localhost for IPv4.
@@ -26,7 +26,7 @@
             // i.e. whether there's an existing service worker.
             if (navigator.serviceWorker.controller) {
               // The updatefound event implies that registration.installing is set
-              const installingWorker = registration.installing;
+              var installingWorker = registration.installing;
 
               installingWorker.onstatechange = function() {
                 switch (installingWorker.state) {


### PR DESCRIPTION
Old versions of Internet Explorer do not support `const`.