### PR TITLE
Update meta.js

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -17,7 +17,7 @@ module.exports = {
     "short_name": {
       "type": "string",
       "required": false,
-      "message": "Project short name: fewer than 12 characters to not be truncated on homescreens (default: same as name)",
+      "message": "Project short name: fewer than 12 characters to not be truncated on homescreens (default: same as name)"
     },
     "description": {
       "type": "string",


### PR DESCRIPTION
removed trailing comma in "short_name" entry.

**Reasons**:
- Consistency
- It will cause invalid JSON parsing, should we ever need it.
