### PR TITLE
Switch to uglifyjs-webpack-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See ["Configuring your Web server to prevent caching"](docs/prevent_caching.md) 
   - Source maps
 
 - `npm run build`: Production ready build.
-  - JavaScript minified with [UglifyJS](https://github.com/mishoo/UglifyJS2).
+  - JavaScript minified with [UglifyJS v3](https://github.com/mishoo/UglifyJS2/tree/harmony).
   - HTML minified with [html-minifier](https://github.com/kangax/html-minifier).
   - CSS across all components extracted into a single file and minified with [cssnano](https://github.com/ben-eb/cssnano).
   - All static assets compiled with version hashes for efficient long-term caching, and a production `index.html` is auto-generated with proper URLs to these generated assets.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,7 @@ All build commands are executed via [NPM Scripts](https://docs.npmjs.com/misc/sc
 
 > Build assets for production. See [Integrating with Backend Framework](backend.md) for more details.
 
-- JavaScript minified with [UglifyJS](https://github.com/mishoo/UglifyJS2).
+- JavaScript minified with [UglifyJS v3](https://github.com/mishoo/UglifyJS2/tree/harmony).
 - HTML minified with [html-minifier](https://github.com/kangax/html-minifier).
 - CSS across all components extracted into a single file and minified with [cssnano](https://github.com/ben-eb/cssnano).
 - All static assets compiled with version hashes for efficient long-term caching, and a production `index.html` is auto-generated with proper URLs to these generated assets.

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -12,6 +12,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const loadMinified = require('./load-minified')
 
 const env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
@@ -36,11 +37,14 @@ const webpackConfig = merge(baseWebpackConfig, {
     new webpack.DefinePlugin({
       'process.env': env
     }),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
+    new UglifyJsPlugin({
+      uglifyOptions: {
+        compress: {
+          warnings: false
+        }
       },
-      sourceMap: true
+      sourceMap: config.build.productionSourceMap,
+      parallel: true
     }),
     // extract css into its own file
     new ExtractTextPlugin({

--- a/template/package.json
+++ b/template/package.json
@@ -90,6 +90,7 @@
     "optimize-css-assets-webpack-plugin": "^3.2.0",
     "ora": "^1.3.0",
     "rimraf": "^2.6.2",
+    "uglifyjs-webpack-plugin": "^1.1.2",
     "url-loader": "^0.6.2",
     "vue-loader": "^13.3.0",
     "vue-style-loader": "^3.0.3",


### PR DESCRIPTION
### Summary

This switches to [`uglifyjs-webpack-plugin`](https://github.com/webpack-contrib/uglifyjs-webpack-plugin) which uses [UglifyJS v3 (`uglify-es`)](https://npmjs.com/package/uglify-es) to minify JavaScript. 

### Why is this required

Right now, we use `babel-preset-env` with some browser versions as the target. This dynamic config may break minification because currently the uglify plugin shipped in webpack 3 doesn't support ES6+. For example, if I change my `target.browsers` to `["last 2 Chrome versions", "last 2 Firefox versions"]` it will break uglify. Since this template is meant to be customised by developers, it would be better to have a more robust method for minification.

Also see discussion in vuejs-templates/pwa#44.

_Note: This PR is a clone of vuejs-templates/webpack#1119(merged)_