### PR TITLE
Update usage in readme to init from development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ $ npm install
 $ npm run dev
 ```
 
+This will scaffold the project using the `master` branch. If you wish to use the latest version of the PWA template, do the following instead:
+
+``` bash
+$ vue init pwa#development my-project
+```
+
+:warning: **The `development` branch is not considered stable and can contain bugs or not build at all, so use at your own risk.**
+
 If port 8080 is already in use on your machine you must change the port number in `/config/index.js`. Otherwise `npm run dev` will fail.
 
 ## What's not Included


### PR DESCRIPTION
This adds instructions to initialise the project from `development` branch to be able to get the latest changes.

Preview link - [sudo-suhas/pwa:README.md@`doc-init-development`#usage](https://github.com/sudo-suhas/pwa/blob/doc-init-development/README.md#usage)

_Note: This PR is a clone of vuejs-templates/webpack#1092(merged)_