### PR TITLE
Change engine>node{4 => 6} for template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -102,7 +102,7 @@
     "uglify-es": "^3.1.3"
   },
   "engines": {
-    "node": ">= 4.0.0",
+    "node": ">= 6.0.0",
     "npm": ">= 3.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
The template is no longer compatible with node 4. If I create a project from the development branch and try to do `npm run dev`, I see this:

```
 ERROR  Failed to compile with 2 errors                                                                                                                       8:32:08 AM

 error  in ./src/App.vue
Syntax Error: Unexpected token {
 @ ./src/main.js 2:0-24
 @ multi ./build/dev-client ./src/main.js

 error  in ./src/components/Hello.vue
Syntax Error: Unexpected token {
 @ ./src/router/index.js 3:0-39
 @ ./src/main.js
 @ multi ./build/dev-client ./src/main.js

> Listening at http://localhost:8080
```
This updates the engines>node field in the template package.json to indicate the minimum required version.

_Note: This PR is a clone of vuejs-templates/webpack#1206(merged)_