### PR TITLE
Maintenance mode message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Maintenance Mode
-**The code in this repo is in maintenance mode, with limited plans for future changes. If you have an issue with the current codebase, we encourage you to try out [`vue-cli` 3.0](https://github.com/vuejs/vue-cli/blob/dev/README.md), using its [new `pwa` plugin](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-pwa), which is being actively developed.**
+**The code in this repo is in maintenance mode, with limited plans for future changes. Our focus moving forward is adding PWA support to [Vue CLI 3.0](https://github.com/vuejs/vue-cli/blob/dev/README.md), using its new [`pwa` plugin](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-pwa). We encourage this work to be used for new projects as it is being actively developed. If you have issues with the current codebase, give the new version a spin and let us know what you think.**
 
 # vue-pwa-boilerplate
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Maintenance Mode
+**The code in this repo is in maintenance mode, with limited plans for future changes. If you have an issue with the current codebase, we encourage you to try out [`vue-cli` 3.0](https://github.com/vuejs/vue-cli/blob/dev/README.md), using its [new `pwa` plugin](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-pwa), which is being actively developed.**
+
 # vue-pwa-boilerplate
 
 > A full-featured [PWA](https://developers.google.com/web/progressive-web-apps/) template with webpack, hot-reload, lint-on-save, unit testing & css extraction.


### PR DESCRIPTION
R: @addyosmani, whom I discussed this with out-of-band.
CC: @yyx990803, in case there are any concerns, specifically about the readiness of pointing people to `vue-cli` 3.0 as an alternative at this point.

I wanted to reflect the reality of the current state of this template, as the `pwa` template that ships with `vue-cli` is where our efforts will be devoted moving forward.

Fixes #190 